### PR TITLE
Support git+http(s) without specifying ref.

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -40,13 +40,14 @@ rec {
   parseGitRef = str:
     let
       parts = builtins.split "[#]" str;
+      partsLength = builtins.length parts;
     in
-    assert !(builtins.length parts == 3) ->
-      builtins.throw "[npmlock2nix] failed to parse Git reference `${str}`. Expected a string of format `git+http(s)://domain.tld/repo#branch`";
+    assert !(builtins.elem (partsLength) [ 1 3 ]) ->
+      builtins.throw "[npmlock2nix] failed to parse Git reference `${str}`. Expected a string of format `git+http(s)://domain.tld/repo(#branch)`";
     rec {
       inherit parts;
       url = builtins.replaceStrings [ "git+" ] [ "" ] (builtins.elemAt parts 0);
-      rev = builtins.elemAt parts 2;
+      rev = if partsLength == 3 then (builtins.elemAt parts 2) else "HEAD";
     };
 
   # Description: Takes a string of the format "github:org/repo#revision" and returns

--- a/tests/examples-projects/github-dependency-branch/default.nix
+++ b/tests/examples-projects/github-dependency-branch/default.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import ../../../nix { } }:
+
+pkgs.npmlock2nix.node_modules {
+  src = ./.;
+  packageJson = ./package.json;
+  packageLockJson = ./package-lock.json;
+  githubSourceHashMap = {
+    tmcw.leftpad.db1442a0556c2b133627ffebf455a78a1ced64b9 = "1zyy1nxbby4wcl30rc8fsis1c3f7nafavnwd3qi4bg0x00gxjdnh";
+  };
+}

--- a/tests/examples-projects/github-dependency-branch/package-lock.json
+++ b/tests/examples-projects/github-dependency-branch/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "github-dependency",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "leftpad": {
+      "version": "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9",
+      "from": "github:tmcw/leftpad#master"
+    }
+  }
+}

--- a/tests/examples-projects/github-dependency-branch/package.json
+++ b/tests/examples-projects/github-dependency-branch/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "github-dependency",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "leftpad": "github:tmcw/leftpad#master"
+  }
+}

--- a/tests/patch-packagefile.nix
+++ b/tests/patch-packagefile.nix
@@ -4,12 +4,20 @@ let
   i = npmlock2nix.internal;
 in
 (testLib.runTests {
-  testTurnsGitHubRefsToStorePaths = {
+  testTurnsGitHubRefsToWildcards = {
     expr =
       let
         leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency/package.json).dependencies.leftpad;
       in
-      lib.hasPrefix ("file://" + builtins.storeDir) leftpad;
+      leftpad == "*";
+    expected = true;
+  };
+  testHandlesBranches = {
+    expr =
+      let
+        leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency-branch/package.json).dependencies.leftpad;
+      in
+      leftpad == "*";
     expected = true;
   };
   testHandlesDevDependencies = {
@@ -17,7 +25,7 @@ in
       let
         leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
       in
-      lib.hasPrefix ("file://" + builtins.storeDir) leftpad;
+      leftpad == "*";
     expected = true;
   };
 })


### PR DESCRIPTION
I haven't completely verified if this works because now I'm running into https://github.com/tweag/npmlock2nix/issues/45, but it does evaluate.